### PR TITLE
Add CTS page and filter BLE scan results

### DIFF
--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -11,20 +11,11 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:vcd_config/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
+  testWidgets('App loads and shows BLE Devices screen', (WidgetTester tester) async {
     // Build our app and trigger a frame.
     await tester.pumpWidget(const MyApp());
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Verify that the devices list page is shown.
+    expect(find.text('BLE Devices'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- filter scan results to show devices named `SPSA-VCD`
- navigate to a new page on tap
- implement `CurrentTimePage` to read and display the Current Time Service
- update widget test

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_688ae0e5ff208323b894bb12cc1ba1fc