### PR TITLE
Add Start-on-Wake toggle and initial/secondary spray schedule configuration

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -311,6 +311,7 @@ class CurrentTimePage extends StatefulWidget {
 }
 
 class _CurrentTimePageState extends State<CurrentTimePage> {
+  static const int _wakeMagicEpochSeconds = 1;
   bool _isConnecting = true;
   String _status = 'Connecting...';
   String? _currentTime;
@@ -792,35 +793,49 @@ class _CurrentTimePageState extends State<CurrentTimePage> {
 
   /// Write the spray schedule to the device.
   Future<void> _setSchedule(
-      DateTime start, int repeatSeconds, int amountMl, String periodLabel) async {
+    DateTime start,
+    int repeatSeconds,
+    int repeatCount,
+    int amountMl,
+    String periodLabel,
+  ) async {
     try {
       final scheduleChar = await _findCharacteristic(
         '02001234-5678-1234-1234-5678abcdeff1',
       );
 
       if (scheduleChar != null) {
-        final DateTime startUtc = DateTime(
-          start.year,
-          start.month,
-          start.day,
-          start.hour,
-          start.minute,
-        ).toUtc();
-
-        DateTime adjustedStart = startUtc;
-
-        final DateTime minScheduleTime =
-            DateTime.now().toUtc().add(const Duration(seconds: 5));
-        if (adjustedStart.isBefore(minScheduleTime)) {
-          debugPrint(
-            'Adjusting start time from ${startUtc.toIso8601String()} to ensure at least 5 seconds lead time',
+        final bool isWakeStart =
+            start.millisecondsSinceEpoch == _wakeMagicEpochSeconds * 1000;
+        DateTime adjustedStart;
+        if (isWakeStart) {
+          adjustedStart = DateTime.fromMillisecondsSinceEpoch(
+            _wakeMagicEpochSeconds * 1000,
+            isUtc: true,
           );
-          adjustedStart = minScheduleTime;
+        } else {
+          final DateTime startUtc = DateTime(
+            start.year,
+            start.month,
+            start.day,
+            start.hour,
+            start.minute,
+          ).toUtc();
+
+          adjustedStart = startUtc;
+
+          final DateTime minScheduleTime =
+              DateTime.now().toUtc().add(const Duration(seconds: 5));
+          if (adjustedStart.isBefore(minScheduleTime)) {
+            debugPrint(
+              'Adjusting start time from ${startUtc.toIso8601String()} to ensure at least 5 seconds lead time',
+            );
+            adjustedStart = minScheduleTime;
+          }
         }
 
         final int startEpoch = adjustedStart.millisecondsSinceEpoch ~/ 1000;
         final int repeatPeriod = repeatSeconds;
-        const int repeatCount = 0xFFFFFFFF;
 
         final data = ByteData(20);
         data.setUint64(0, startEpoch, Endian.little);
@@ -831,13 +846,20 @@ class _CurrentTimePageState extends State<CurrentTimePage> {
 
         await scheduleChar.write(data.buffer.asUint8List(), withoutResponse: false);
         if (mounted) {
-          final localStart = DateTime.fromMillisecondsSinceEpoch(startEpoch * 1000).toLocal();
-          final time = TimeOfDay.fromDateTime(localStart).format(context);
-          final date = MaterialLocalizations.of(context).formatFullDate(localStart);
+          final String scheduleStartLabel;
+          if (isWakeStart) {
+            scheduleStartLabel = 'Start on Wake';
+          } else {
+            final localStart =
+                DateTime.fromMillisecondsSinceEpoch(startEpoch * 1000).toLocal();
+            final time = TimeOfDay.fromDateTime(localStart).format(context);
+            final date = MaterialLocalizations.of(context).formatFullDate(localStart);
+            scheduleStartLabel = '$date at $time';
+          }
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
                 content: Text(
-                    'Schedule set for $date at $time every $periodLabel, $amountMl ml')),
+                    'Schedule set for $scheduleStartLabel every $periodLabel, $amountMl ml')),
           );
         }
       } else {
@@ -865,14 +887,18 @@ class _CurrentTimePageState extends State<CurrentTimePage> {
     );
     if (result != null && mounted) {
       final DateTime start = result['start'] as DateTime;
-      final int repeat = result['repeatSeconds'] as int;
-      final int amount = result['amountMl'] as int;
+      final int repeat = result['initialRepeatSeconds'] as int;
+      final int repeatCount = result['initialRepeatCount'] as int;
+      final int amount = result['initialAmountMl'] as int;
       final String label = _formatPeriod(repeat);
-      await _setSchedule(start, repeat, amount, label);
+      await _setSchedule(start, repeat, repeatCount, amount, label);
     }
   }
 
   String _formatPeriod(int seconds) {
+    if (seconds == 0) {
+      return 'never';
+    }
     if (seconds >= 3600) {
       final hours = seconds ~/ 3600;
       return hours == 1 ? '1 hour' : '$hours hours';

--- a/lib/spray_schedule_page.dart
+++ b/lib/spray_schedule_page.dart
@@ -12,11 +12,49 @@ class SpraySchedulePage extends StatefulWidget {
 }
 
 class _SpraySchedulePageState extends State<SpraySchedulePage> {
+  static const int _wakeMagicEpochSeconds = 1;
+  static final DateTime _wakeMagicDateTime =
+      DateTime.fromMillisecondsSinceEpoch(
+    _wakeMagicEpochSeconds * 1000,
+    isUtc: true,
+  );
+
   late TimeOfDay _startTime;
   late DateTime _startDate;
-  int _repeatSeconds = 60;
+  bool _startOnWake = false;
+  int _initialRepeatSeconds = 60;
+  int _secondaryRepeatSeconds = 0;
+  int _initialRepeatCount = _repeatCountForever;
+  int _secondaryRepeatCount = _repeatCountForever;
   late List<int> _amountOptions;
-  int? _amountMl;
+  int _initialAmountMl = 0;
+  int _secondaryAmountMl = 0;
+
+  static const int _repeatCountForever = 0xFFFFFFFF;
+  static const List<int> _repeatCountOptions = [
+    1,
+    2,
+    3,
+    4,
+    5,
+    10,
+    20,
+    _repeatCountForever,
+  ];
+
+  static const List<_PeriodOption> _periodOptions = [
+    _PeriodOption(seconds: 0, label: 'Never'),
+    _PeriodOption(seconds: 30, label: '30 sec'),
+    _PeriodOption(seconds: 60, label: '1 min'),
+    _PeriodOption(seconds: 300, label: '5 min'),
+    _PeriodOption(seconds: 900, label: '15 min'),
+    _PeriodOption(seconds: 1800, label: '30 min'),
+    _PeriodOption(seconds: 3600, label: '1 hour'),
+    _PeriodOption(seconds: 7200, label: '2 hours'),
+    _PeriodOption(seconds: 21600, label: '6 hours'),
+    _PeriodOption(seconds: 43200, label: '12 hours'),
+    _PeriodOption(seconds: 86400, label: '24 hours'),
+  ];
 
   @override
   void initState() {
@@ -25,7 +63,7 @@ class _SpraySchedulePageState extends State<SpraySchedulePage> {
     _startTime = TimeOfDay.fromDateTime(_startDate);
     _amountOptions = widget.allowedAmounts.toSet().toList()..sort();
     if (_amountOptions.isNotEmpty) {
-      _amountMl = _amountOptions.first;
+      _initialAmountMl = _amountOptions.first;
     }
   }
 
@@ -57,21 +95,182 @@ class _SpraySchedulePageState extends State<SpraySchedulePage> {
   }
 
   void _save() {
-    if (_amountMl == null) {
+    if (_initialAmountMl == 0 || _initialRepeatSeconds == 0) {
       return;
     }
-    final startDateTime = DateTime(
-      _startDate.year,
-      _startDate.month,
-      _startDate.day,
-      _startTime.hour,
-      _startTime.minute,
-    );
+    final startDateTime = _startOnWake
+        ? _wakeMagicDateTime
+        : DateTime(
+            _startDate.year,
+            _startDate.month,
+            _startDate.day,
+            _startTime.hour,
+            _startTime.minute,
+          );
     Navigator.of(context).pop({
       'start': startDateTime,
-      'repeatSeconds': _repeatSeconds,
-      'amountMl': _amountMl!,
+      'initialRepeatSeconds': _initialRepeatSeconds,
+      'initialRepeatCount': _initialRepeatCount,
+      'initialAmountMl': _initialAmountMl,
+      'secondaryRepeatSeconds': _secondaryRepeatSeconds,
+      'secondaryRepeatCount': _secondaryRepeatCount,
+      'secondaryAmountMl': _secondaryAmountMl,
     });
+  }
+
+  Widget _buildStartModeButton({
+    required String label,
+    required bool isSelected,
+    required VoidCallback onPressed,
+  }) {
+    return Expanded(
+      child: GestureDetector(
+        onTap: onPressed,
+        child: Container(
+          padding: const EdgeInsets.all(2),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(12),
+            gradient: isSelected
+                ? const LinearGradient(
+                    colors: [Color(0xFFFF9800), Color(0xFFFFB300)],
+                  )
+                : null,
+            border: isSelected
+                ? null
+                : Border.all(
+                    color: Colors.black.withOpacity(0.2),
+                  ),
+          ),
+          child: Container(
+            padding: const EdgeInsets.symmetric(vertical: 12),
+            decoration: BoxDecoration(
+              color: Colors.white.withOpacity(0.9),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Center(
+              child: Text(
+                label,
+                style: TextStyle(
+                  fontWeight: FontWeight.w600,
+                  color: isSelected ? Colors.deepOrange : Colors.black87,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildScheduleSection({
+    required String title,
+    required int repeatSeconds,
+    required ValueChanged<int> onRepeatSecondsChanged,
+    required int amountMl,
+    required ValueChanged<int> onAmountChanged,
+    required int repeatCount,
+    required ValueChanged<int> onRepeatCountChanged,
+  }) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      margin: const EdgeInsets.only(top: 8),
+      decoration: BoxDecoration(
+        color: Colors.white.withOpacity(0.85),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: const TextStyle(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              const Text('Spray Period:'),
+              const SizedBox(width: 16),
+              DropdownButton<int>(
+                value: repeatSeconds,
+                onChanged: (value) {
+                  if (value != null) {
+                    onRepeatSecondsChanged(value);
+                  }
+                },
+                items: _periodOptions
+                    .map(
+                      (option) => DropdownMenuItem(
+                        value: option.seconds,
+                        child: Text(option.label),
+                      ),
+                    )
+                    .toList(),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              const Text('Amount:'),
+              const SizedBox(width: 16),
+              Expanded(
+                child: DropdownButton<int>(
+                  isExpanded: true,
+                  value: amountMl,
+                  onChanged: _amountOptions.isEmpty
+                      ? null
+                      : (value) {
+                          if (value != null) {
+                            onAmountChanged(value);
+                          }
+                        },
+                  items: [
+                    const DropdownMenuItem(
+                      value: 0,
+                      child: Text('None'),
+                    ),
+                    ..._amountOptions.map(
+                      (amount) => DropdownMenuItem(
+                        value: amount,
+                        child: Text('$amount ml'),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              const Text('Repeat Count:'),
+              const SizedBox(width: 16),
+              DropdownButton<int>(
+                value: repeatCount,
+                onChanged: (value) {
+                  if (value != null) {
+                    onRepeatCountChanged(value);
+                  }
+                },
+                items: _repeatCountOptions
+                    .map(
+                      (count) => DropdownMenuItem(
+                        value: count,
+                        child: Text(
+                          count == _repeatCountForever
+                              ? 'Forever'
+                              : '$count times',
+                        ),
+                      ),
+                    )
+                    .toList(),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
   }
 
   @override
@@ -93,84 +292,93 @@ class _SpraySchedulePageState extends State<SpraySchedulePage> {
           padding: const EdgeInsets.all(16),
           child: Column(
             children: [
-              ListTile(
-                title: const Text('Start Date'),
-                subtitle: Text(
-                  MaterialLocalizations.of(context).formatFullDate(_startDate),
-                ),
-                trailing: IconButton(
-                  icon: const Icon(Icons.calendar_today),
-                  onPressed: _pickStartDate,
-                ),
-              ),
-              const SizedBox(height: 8),
-              ListTile(
-                title: const Text('Start Time'),
-                subtitle: Text(_startTime.format(context)),
-                trailing: IconButton(
-                  icon: const Icon(Icons.access_time),
-                  onPressed: _pickStartTime,
-                ),
-              ),
-              const SizedBox(height: 16),
               Row(
                 children: [
-                  const Text('Repeat Every:'),
-                  const SizedBox(width: 16),
-                  DropdownButton<int>(
-                    value: _repeatSeconds,
-                    onChanged: (value) {
-                      if (value != null) {
-                        setState(() {
-                          _repeatSeconds = value;
-                        });
-                      }
+                  _buildStartModeButton(
+                    label: 'Start Date/Time',
+                    isSelected: !_startOnWake,
+                    onPressed: () {
+                      setState(() {
+                        _startOnWake = false;
+                      });
                     },
-                    items: const [
-                      DropdownMenuItem(value: 30, child: Text('30 sec')),
-                      DropdownMenuItem(value: 60, child: Text('1 min')),
-                      DropdownMenuItem(value: 300, child: Text('5 min')),
-                      DropdownMenuItem(value: 900, child: Text('15 min')),
-                      DropdownMenuItem(value: 1800, child: Text('30 min')),
-                      DropdownMenuItem(value: 3600, child: Text('1 hour')),
-                      DropdownMenuItem(value: 7200, child: Text('2 hours')),
-                      DropdownMenuItem(value: 21600, child: Text('6 hours')),
-                      DropdownMenuItem(value: 43200, child: Text('12 hours')),
-                      DropdownMenuItem(value: 86400, child: Text('24 hours')),
-                    ],
+                  ),
+                  const SizedBox(width: 12),
+                  _buildStartModeButton(
+                    label: 'Start on Wake',
+                    isSelected: _startOnWake,
+                    onPressed: () {
+                      setState(() {
+                        _startOnWake = true;
+                      });
+                    },
                   ),
                 ],
               ),
-              const SizedBox(height: 16),
-              Row(
-                children: [
-                  const Text('Amount:'),
-                  const SizedBox(width: 16),
-                  Expanded(
-                    child: DropdownButton<int>(
-                      isExpanded: true,
-                      value: _amountMl,
-                      hint: const Text('Select amount'),
-                      onChanged: _amountOptions.isEmpty
-                          ? null
-                          : (value) {
-                              if (value != null) {
-                                setState(() {
-                                  _amountMl = value;
-                                });
-                              }
-                            },
-                      items: _amountOptions
-                          .map(
-                            (amount) => DropdownMenuItem(
-                              value: amount,
-                              child: Text('$amount ml'),
-                            ),
-                          )
-                          .toList(),
-                    ),
+              if (!_startOnWake) ...[
+                const SizedBox(height: 12),
+                ListTile(
+                  title: const Text('Start Date'),
+                  subtitle: Text(
+                    MaterialLocalizations.of(context).formatFullDate(_startDate),
                   ),
-                ],
+                  trailing: IconButton(
+                    icon: const Icon(Icons.calendar_today),
+                    onPressed: _pickStartDate,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                ListTile(
+                  title: const Text('Start Time'),
+                  subtitle: Text(_startTime.format(context)),
+                  trailing: IconButton(
+                    icon: const Icon(Icons.access_time),
+                    onPressed: _pickStartTime,
+                  ),
+                ),
+              ],
+              const SizedBox(height: 16),
+              _buildScheduleSection(
+                title: 'Initial Spray',
+                repeatSeconds: _initialRepeatSeconds,
+                onRepeatSecondsChanged: (value) {
+                  setState(() {
+                    _initialRepeatSeconds = value;
+                  });
+                },
+                amountMl: _initialAmountMl,
+                onAmountChanged: (value) {
+                  setState(() {
+                    _initialAmountMl = value;
+                  });
+                },
+                repeatCount: _initialRepeatCount,
+                onRepeatCountChanged: (value) {
+                  setState(() {
+                    _initialRepeatCount = value;
+                  });
+                },
+              ),
+              _buildScheduleSection(
+                title: 'Secondary Spray',
+                repeatSeconds: _secondaryRepeatSeconds,
+                onRepeatSecondsChanged: (value) {
+                  setState(() {
+                    _secondaryRepeatSeconds = value;
+                  });
+                },
+                amountMl: _secondaryAmountMl,
+                onAmountChanged: (value) {
+                  setState(() {
+                    _secondaryAmountMl = value;
+                  });
+                },
+                repeatCount: _secondaryRepeatCount,
+                onRepeatCountChanged: (value) {
+                  setState(() {
+                    _secondaryRepeatCount = value;
+                  });
+                },
               ),
               if (_amountOptions.isEmpty)
                 const Padding(
@@ -182,7 +390,10 @@ class _SpraySchedulePageState extends State<SpraySchedulePage> {
                 ),
               const Spacer(),
               ElevatedButton(
-                onPressed: _amountMl == null ? null : _save,
+                onPressed:
+                    _initialAmountMl == 0 || _initialRepeatSeconds == 0
+                        ? null
+                        : _save,
                 style: ElevatedButton.styleFrom(
                   backgroundColor: Colors.amber.shade700,
                   foregroundColor: Colors.black,
@@ -195,4 +406,11 @@ class _SpraySchedulePageState extends State<SpraySchedulePage> {
       ),
     );
   }
+}
+
+class _PeriodOption {
+  final int seconds;
+  final String label;
+
+  const _PeriodOption({required this.seconds, required this.label});
 }


### PR DESCRIPTION
### Motivation
- Provide a Start-on-Wake option alongside explicit start date/time and allow users to configure two sequential spray configurations (initial and secondary) each with period, amount, and repeat-count so an initial pattern can run X times then switch to a different pattern.

### Description
- Added a start-mode toggle UI in `lib/spray_schedule_page.dart` with two horizontally adjacent buttons (`Start Date/Time` and `Start on Wake`) where the selected button shows an orange gradient style and the other appears unselected.
- Implemented a wake-magic timestamp (`_wakeMagicEpochSeconds = 1`) and map `Start on Wake` to a special `DateTime` so the app can detect wake-starts internally; date/time pickers remain available when `Start Date/Time` is selected.
- Reworked the schedule UI to include `Initial Spray` and `Secondary Spray` sections with `Spray Period` (adds `Never` option), `Amount` (adds `None` as `0`), and `Repeat Count` (adds numeric options plus `Forever` using `0xFFFFFFFF`) in `lib/spray_schedule_page.dart` and added helper widgets `_buildStartModeButton` and `_buildScheduleSection`.
- Updated schedule payload handling in `lib/main.dart` and `CurrentTimePage` to accept and write a `repeatCount` field into the schedule byte payload, to respect the wake-magic start marker (skip min-lead-time adjustment for wake-start) and to format confirmation snackbars accordingly, and to use the `initial*` fields returned from the schedule page when writing the schedule.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697ab530a0a08323ac9937995d8dc2c4)