### PR TITLE
Send secondary schedule over BLE and move calibration UI to subpage

### DIFF
--- a/lib/calibration_entry.dart
+++ b/lib/calibration_entry.dart
@@ -1,0 +1,11 @@
+class CalibrationEntry {
+  final int slot;
+  final int dosageMl;
+  final int sprayTimeMs;
+
+  const CalibrationEntry({
+    required this.slot,
+    required this.dosageMl,
+    required this.sprayTimeMs,
+  });
+}

--- a/lib/calibration_page.dart
+++ b/lib/calibration_page.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+
+import 'calibration_entry.dart';
+
+class CalibrationPageData {
+  final List<CalibrationEntry> calibrations;
+  final String? error;
+  final bool isReading;
+
+  const CalibrationPageData({
+    required this.calibrations,
+    required this.error,
+    required this.isReading,
+  });
+}
+
+class CalibrationPage extends StatefulWidget {
+  final CalibrationPageData initialData;
+  final Future<CalibrationPageData> Function() onRefresh;
+  final Future<void> Function(int slot) onEditSlot;
+
+  const CalibrationPage({
+    super.key,
+    required this.initialData,
+    required this.onRefresh,
+    required this.onEditSlot,
+  });
+
+  @override
+  State<CalibrationPage> createState() => _CalibrationPageState();
+}
+
+class _CalibrationPageState extends State<CalibrationPage> {
+  late List<CalibrationEntry> _calibrations;
+  String? _error;
+  bool _isReading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _calibrations = widget.initialData.calibrations;
+    _error = widget.initialData.error;
+    _isReading = widget.initialData.isReading;
+  }
+
+  Future<void> _refresh() async {
+    setState(() {
+      _isReading = true;
+    });
+    final data = await widget.onRefresh();
+    if (!mounted) {
+      return;
+    }
+    setState(() {
+      _calibrations = data.calibrations;
+      _error = data.error;
+      _isReading = data.isReading;
+    });
+  }
+
+  Future<void> _editSlot(int slot) async {
+    await widget.onEditSlot(slot);
+    await _refresh();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Calibration Data'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: _refresh,
+          ),
+        ],
+      ),
+      body: Container(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+            colors: [Color(0xFFFFE082), Color(0xFFFFCA28)],
+            transform: GradientRotation(30 * 3.141592653589793 / 180),
+          ),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: _buildCalibrationSection(),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCalibrationSection() {
+    if (_isReading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (_error != null && _calibrations.isEmpty) {
+      return Text(
+        _error!,
+        textAlign: TextAlign.center,
+        style: const TextStyle(fontSize: 16),
+      );
+    }
+    final cards = List<Widget>.generate(kMaxCalibrationEntries, (slot) {
+      final entry =
+          _calibrations.cast<CalibrationEntry?>().firstWhere(
+                (item) => item?.slot == slot,
+                orElse: () => null,
+              );
+      final subtitle = entry != null
+          ? 'Dose: ${entry.dosageMl} ml\nSpray Time: ${entry.sprayTimeMs} ms'
+          : 'Empty slot';
+      return Card(
+        color: Colors.white,
+        child: ListTile(
+          title: Text('Slot ${slot + 1}'),
+          subtitle: Text(subtitle),
+          isThreeLine: entry != null,
+          trailing: const Icon(Icons.edit),
+          onTap: () => _editSlot(slot),
+        ),
+      );
+    });
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'Calibration Data',
+          style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 8),
+        Expanded(
+          child: ListView(
+            children: [
+              ...cards,
+              if (_error != null)
+                Padding(
+                  padding: const EdgeInsets.only(top: 8),
+                  child: Text(
+                    _error!,
+                    style: const TextStyle(color: Colors.red),
+                  ),
+                ),
+              if (_calibrations.isEmpty)
+                const Padding(
+                  padding: EdgeInsets.only(top: 8),
+                  child: Text(
+                    'Tap a slot above to add calibration data for the device.',
+                    style: TextStyle(fontStyle: FontStyle.italic),
+                  ),
+                ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+const int kMaxCalibrationEntries = 5;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -794,14 +794,6 @@ class _CurrentTimePageState extends State<CurrentTimePage> {
 
           adjustedStart = startUtc;
 
-          final DateTime minScheduleTime =
-              DateTime.now().toUtc().add(const Duration(seconds: 5));
-          if (adjustedStart.isBefore(minScheduleTime)) {
-            debugPrint(
-              'Adjusting start time from ${startUtc.toIso8601String()} to ensure at least 5 seconds lead time',
-            );
-            adjustedStart = minScheduleTime;
-          }
         }
 
         final int startEpoch = adjustedStart.millisecondsSinceEpoch ~/ 1000;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -869,7 +869,7 @@ class _CurrentTimePageState extends State<CurrentTimePage> {
       final int secondaryRepeat = result['secondaryRepeatSeconds'] as int;
       final int secondaryRepeatCount = result['secondaryRepeatCount'] as int;
       final int secondaryAmount = result['secondaryAmountMl'] as int;
-      if (secondaryRepeat > 0 && secondaryAmount > 0) {
+      if (secondaryRepeat > 0) {
         if (repeatCount == repeatCountForever) {
           if (mounted) {
             ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -308,6 +308,7 @@ class _CurrentTimePageState extends State<CurrentTimePage> {
   List<BluetoothService>? _services;
   List<CalibrationEntry> _calibrations = [];
   bool _isReadingCalibration = false;
+  bool _isReadingSchedule = false;
   String? _calibrationError;
 
   @override
@@ -834,11 +835,111 @@ class _CurrentTimePageState extends State<CurrentTimePage> {
     }
   }
 
+  List<_ScheduleEntry> _parseSchedules(Uint8List raw) {
+    const int scheduleByteLength = 20;
+    if (raw.length < scheduleByteLength) {
+      return const <_ScheduleEntry>[];
+    }
+    final byteData = ByteData.sublistView(raw);
+    final int scheduleCount = raw.length ~/ scheduleByteLength;
+    final List<_ScheduleEntry> schedules = [];
+    for (int i = 0; i < scheduleCount; i++) {
+      final int offset = i * scheduleByteLength;
+      final int startEpochSeconds = byteData.getUint64(offset, Endian.little);
+      final int repeatSeconds = byteData.getUint32(offset + 8, Endian.little);
+      final int repeatCount = byteData.getUint32(offset + 12, Endian.little);
+      final int amountMl = byteData.getUint16(offset + 16, Endian.little);
+      if (startEpochSeconds == 0 &&
+          repeatSeconds == 0 &&
+          repeatCount == 0 &&
+          amountMl == 0) {
+        continue;
+      }
+
+      final DateTime start = startEpochSeconds == _wakeMagicEpochSeconds
+          ? DateTime.fromMillisecondsSinceEpoch(
+              _wakeMagicEpochSeconds * 1000,
+              isUtc: true,
+            )
+          : DateTime.fromMillisecondsSinceEpoch(
+              startEpochSeconds * 1000,
+              isUtc: true,
+            ).toLocal();
+
+      schedules.add(
+        _ScheduleEntry(
+          start: start,
+          repeatSeconds: repeatSeconds,
+          repeatCount: repeatCount,
+          amountMl: amountMl,
+          periodLabel: _formatPeriod(repeatSeconds),
+        ),
+      );
+    }
+    return schedules;
+  }
+
+  Future<SprayScheduleInitialData?> _readScheduleFromVcd() async {
+    final scheduleChar = await _findCharacteristic(
+      '02001234-5678-1234-1234-5678abcdeff1',
+    );
+    if (scheduleChar == null) {
+      return null;
+    }
+
+    final raw = Uint8List.fromList(await scheduleChar.read());
+    final schedules = _parseSchedules(raw);
+    if (schedules.isEmpty) {
+      return null;
+    }
+
+    const int repeatCountForever = 0xFFFFFFFF;
+    final _ScheduleEntry initial = schedules.first;
+    final _ScheduleEntry? secondary = schedules.length > 1 ? schedules[1] : null;
+    final bool startOnWake =
+        initial.start.millisecondsSinceEpoch == _wakeMagicEpochSeconds * 1000;
+    return SprayScheduleInitialData(
+      start: initial.start,
+      startOnWake: startOnWake,
+      initialRepeatSeconds: initial.repeatSeconds,
+      initialRepeatCount: initial.repeatCount,
+      initialAmountMl: initial.amountMl,
+      secondaryRepeatSeconds: secondary?.repeatSeconds ?? 0,
+      secondaryRepeatCount: secondary?.repeatCount ?? repeatCountForever,
+      secondaryAmountMl: secondary?.amountMl ?? 0,
+    );
+  }
+
   Future<void> _openSchedule() async {
+    if (mounted) {
+      setState(() {
+        _isReadingSchedule = true;
+      });
+    }
+    SprayScheduleInitialData? initialData;
+    try {
+      initialData = await _readScheduleFromVcd();
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to read schedule from VCD: $e')),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isReadingSchedule = false;
+        });
+      }
+    }
+
     final allowedAmounts = _allowedAmountsForSchedule();
     final result = await Navigator.of(context).push<Map<String, dynamic>>(
       MaterialPageRoute(
-        builder: (_) => SpraySchedulePage(allowedAmounts: allowedAmounts),
+        builder: (_) => SpraySchedulePage(
+          allowedAmounts: allowedAmounts,
+          initialData: initialData,
+        ),
       ),
     );
     if (result != null && mounted) {
@@ -948,9 +1049,20 @@ class _CurrentTimePageState extends State<CurrentTimePage> {
                     children: [
                       const SizedBox(height: 24),
                       ElevatedButton(
-                        onPressed: _openSchedule,
+                        onPressed: _isReadingSchedule ? null : _openSchedule,
                         style: buttonStyle,
-                        child: const Text('Schedule Spray'),
+                        child: _isReadingSchedule
+                            ? const SizedBox(
+                                width: 16,
+                                height: 16,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                  valueColor: AlwaysStoppedAnimation<Color>(
+                                    Colors.black,
+                                  ),
+                                ),
+                              )
+                            : const Text('Schedule Spray'),
                       ),
                       const SizedBox(height: 12),
                       Container(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -750,22 +750,33 @@ class _CurrentTimePageState extends State<CurrentTimePage> {
     }
   }
 
-  /// Write the spray schedule to the device.
-  Future<void> _setSchedule(
-    DateTime start,
-    int repeatSeconds,
-    int repeatCount,
-    int amountMl,
-    String periodLabel,
-  ) async {
+  /// Write the spray schedules to the device.
+  Future<void> _setSchedules(List<_ScheduleEntry> schedules) async {
     try {
       final scheduleChar = await _findCharacteristic(
         '02001234-5678-1234-1234-5678abcdeff1',
       );
 
-      if (scheduleChar != null) {
+      if (scheduleChar == null) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Schedule characteristic not found')),
+          );
+        }
+        return;
+      }
+
+      if (schedules.isEmpty) {
+        return;
+      }
+
+      final data = ByteData(20 * schedules.length);
+      final List<String> summaryParts = [];
+      for (int i = 0; i < schedules.length; i++) {
+        final schedule = schedules[i];
         final bool isWakeStart =
-            start.millisecondsSinceEpoch == _wakeMagicEpochSeconds * 1000;
+            schedule.start.millisecondsSinceEpoch ==
+                _wakeMagicEpochSeconds * 1000;
         DateTime adjustedStart;
         if (isWakeStart) {
           adjustedStart = DateTime.fromMillisecondsSinceEpoch(
@@ -774,11 +785,11 @@ class _CurrentTimePageState extends State<CurrentTimePage> {
           );
         } else {
           final DateTime startUtc = DateTime(
-            start.year,
-            start.month,
-            start.day,
-            start.hour,
-            start.minute,
+            schedule.start.year,
+            schedule.start.month,
+            schedule.start.day,
+            schedule.start.hour,
+            schedule.start.minute,
           ).toUtc();
 
           adjustedStart = startUtc;
@@ -794,39 +805,33 @@ class _CurrentTimePageState extends State<CurrentTimePage> {
         }
 
         final int startEpoch = adjustedStart.millisecondsSinceEpoch ~/ 1000;
-        final int repeatPeriod = repeatSeconds;
+        final int offset = i * 20;
+        data.setUint64(offset, startEpoch, Endian.little);
+        data.setUint32(offset + 8, schedule.repeatSeconds, Endian.little);
+        data.setUint32(offset + 12, schedule.repeatCount, Endian.little);
+        data.setUint16(offset + 16, schedule.amountMl, Endian.little);
+        data.setUint16(offset + 18, 0, Endian.little);
 
-        final data = ByteData(20);
-        data.setUint64(0, startEpoch, Endian.little);
-        data.setUint32(8, repeatPeriod, Endian.little);
-        data.setUint32(12, repeatCount, Endian.little);
-        data.setUint16(16, amountMl, Endian.little);
-        data.setUint16(18, 0, Endian.little);
+        final String scheduleStartLabel;
+        if (isWakeStart) {
+          scheduleStartLabel = 'Start on Wake';
+        } else {
+          final localStart =
+              DateTime.fromMillisecondsSinceEpoch(startEpoch * 1000).toLocal();
+          final time = TimeOfDay.fromDateTime(localStart).format(context);
+          final date = MaterialLocalizations.of(context).formatFullDate(localStart);
+          scheduleStartLabel = '$date at $time';
+        }
+        summaryParts.add(
+          '$scheduleStartLabel every ${schedule.periodLabel}, ${schedule.amountMl} ml',
+        );
+      }
 
-        await scheduleChar.write(data.buffer.asUint8List(), withoutResponse: false);
-        if (mounted) {
-          final String scheduleStartLabel;
-          if (isWakeStart) {
-            scheduleStartLabel = 'Start on Wake';
-          } else {
-            final localStart =
-                DateTime.fromMillisecondsSinceEpoch(startEpoch * 1000).toLocal();
-            final time = TimeOfDay.fromDateTime(localStart).format(context);
-            final date = MaterialLocalizations.of(context).formatFullDate(localStart);
-            scheduleStartLabel = '$date at $time';
-          }
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-                content: Text(
-                    'Schedule set for $scheduleStartLabel every $periodLabel, $amountMl ml')),
-          );
-        }
-      } else {
-        if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Schedule characteristic not found')),
-          );
-        }
+      await scheduleChar.write(data.buffer.asUint8List(), withoutResponse: false);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Schedules set: ${summaryParts.join(' | ')}')),
+        );
       }
     } catch (e) {
       if (mounted) {
@@ -851,7 +856,15 @@ class _CurrentTimePageState extends State<CurrentTimePage> {
       final int repeatCount = result['initialRepeatCount'] as int;
       final int amount = result['initialAmountMl'] as int;
       final String label = _formatPeriod(repeat);
-      await _setSchedule(start, repeat, repeatCount, amount, label);
+      final List<_ScheduleEntry> schedules = [
+        _ScheduleEntry(
+          start: start,
+          repeatSeconds: repeat,
+          repeatCount: repeatCount,
+          amountMl: amount,
+          periodLabel: label,
+        ),
+      ];
 
       final int secondaryRepeat = result['secondaryRepeatSeconds'] as int;
       final int secondaryRepeatCount = result['secondaryRepeatCount'] as int;
@@ -875,14 +888,18 @@ class _CurrentTimePageState extends State<CurrentTimePage> {
             ? start
             : start.add(Duration(seconds: repeat * repeatCount));
         final String secondaryLabel = _formatPeriod(secondaryRepeat);
-        await _setSchedule(
-          secondaryStart,
-          secondaryRepeat,
-          secondaryRepeatCount,
-          secondaryAmount,
-          secondaryLabel,
+        schedules.add(
+          _ScheduleEntry(
+            start: secondaryStart,
+            repeatSeconds: secondaryRepeat,
+            repeatCount: secondaryRepeatCount,
+            amountMl: secondaryAmount,
+            periodLabel: secondaryLabel,
+          ),
         );
       }
+
+      await _setSchedules(schedules);
     }
   }
 
@@ -1046,4 +1063,20 @@ class _CurrentTimePageState extends State<CurrentTimePage> {
       ),
     );
   }
+}
+
+class _ScheduleEntry {
+  final DateTime start;
+  final int repeatSeconds;
+  final int repeatCount;
+  final int amountMl;
+  final String periodLabel;
+
+  const _ScheduleEntry({
+    required this.start,
+    required this.repeatSeconds,
+    required this.repeatCount,
+    required this.amountMl,
+    required this.periodLabel,
+  });
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,22 +4,12 @@ import 'dart:typed_data';
 import 'package:flutter/material.dart';
 import 'package:flutter_blue_plus/flutter_blue_plus.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'calibration_entry.dart';
 import 'calibration_form_page.dart';
+import 'calibration_page.dart';
 import 'spray_schedule_page.dart';
 
 const int kMaxCalibrationEntries = 5;
-
-class CalibrationEntry {
-  final int slot;
-  final int dosageMl;
-  final int sprayTimeMs;
-
-  const CalibrationEntry({
-    required this.slot,
-    required this.dosageMl,
-    required this.sprayTimeMs,
-  });
-}
 
 /// Entry point of the application.
 void main() {
@@ -311,6 +301,7 @@ class CurrentTimePage extends StatefulWidget {
 }
 
 class _CurrentTimePageState extends State<CurrentTimePage> {
+  static const int _wakeMagicEpochSeconds = 1;
   bool _isConnecting = true;
   String _status = 'Connecting...';
   String? _currentTime;
@@ -652,6 +643,31 @@ class _CurrentTimePageState extends State<CurrentTimePage> {
     }
   }
 
+  Future<void> _openCalibrationPage() async {
+    await Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => CalibrationPage(
+          initialData: CalibrationPageData(
+            calibrations: _calibrations,
+            error: _calibrationError,
+            isReading: _isReadingCalibration,
+          ),
+          onRefresh: _refreshCalibrationData,
+          onEditSlot: (slot) => _openCalibrationForm(slotIndex: slot),
+        ),
+      ),
+    );
+  }
+
+  Future<CalibrationPageData> _refreshCalibrationData() async {
+    await _readCalibrationData();
+    return CalibrationPageData(
+      calibrations: _calibrations,
+      error: _calibrationError,
+      isReading: _isReadingCalibration,
+    );
+  }
+
   List<int> _allowedAmountsForSchedule() {
     final amounts = _calibrations.map((e) => e.dosageMl).toSet().toList()
       ..sort();
@@ -675,62 +691,6 @@ class _CurrentTimePageState extends State<CurrentTimePage> {
       }
     }
     return null;
-  }
-
-  Widget _buildCalibrationSection() {
-    if (_isReadingCalibration) {
-      return const Center(child: CircularProgressIndicator());
-    }
-    if (_calibrationError != null && _calibrations.isEmpty) {
-      return Text(
-        _calibrationError!,
-        textAlign: TextAlign.center,
-        style: const TextStyle(fontSize: 16),
-      );
-    }
-    final cards = List<Widget>.generate(kMaxCalibrationEntries, (slot) {
-      final entry = _entryForSlot(slot);
-      final subtitle = entry != null
-          ? 'Dose: ${entry.dosageMl} ml\nSpray Time: ${entry.sprayTimeMs} ms'
-          : 'Empty slot';
-      return Card(
-        color: Colors.white,
-        child: ListTile(
-          title: Text('Slot ${slot + 1}'),
-          subtitle: Text(subtitle),
-          isThreeLine: entry != null,
-          trailing: const Icon(Icons.edit),
-          onTap: () => _openCalibrationForm(slotIndex: slot),
-        ),
-      );
-    });
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        const Text(
-          'Calibration Data',
-          style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
-        ),
-        const SizedBox(height: 8),
-        ...cards,
-        if (_calibrationError != null)
-          Padding(
-            padding: const EdgeInsets.only(top: 8),
-            child: Text(
-              _calibrationError!,
-              style: const TextStyle(color: Colors.red),
-            ),
-          ),
-        if (_calibrations.isEmpty)
-          const Padding(
-            padding: EdgeInsets.only(top: 8),
-            child: Text(
-              'Tap a slot above to add calibration data for the device.',
-              style: TextStyle(fontStyle: FontStyle.italic),
-            ),
-          ),
-      ],
-    );
   }
 
   /// Write a value to the LED characteristic to turn the LED on or off.
@@ -792,35 +752,49 @@ class _CurrentTimePageState extends State<CurrentTimePage> {
 
   /// Write the spray schedule to the device.
   Future<void> _setSchedule(
-      DateTime start, int repeatSeconds, int amountMl, String periodLabel) async {
+    DateTime start,
+    int repeatSeconds,
+    int repeatCount,
+    int amountMl,
+    String periodLabel,
+  ) async {
     try {
       final scheduleChar = await _findCharacteristic(
         '02001234-5678-1234-1234-5678abcdeff1',
       );
 
       if (scheduleChar != null) {
-        final DateTime startUtc = DateTime(
-          start.year,
-          start.month,
-          start.day,
-          start.hour,
-          start.minute,
-        ).toUtc();
-
-        DateTime adjustedStart = startUtc;
-
-        final DateTime minScheduleTime =
-            DateTime.now().toUtc().add(const Duration(seconds: 5));
-        if (adjustedStart.isBefore(minScheduleTime)) {
-          debugPrint(
-            'Adjusting start time from ${startUtc.toIso8601String()} to ensure at least 5 seconds lead time',
+        final bool isWakeStart =
+            start.millisecondsSinceEpoch == _wakeMagicEpochSeconds * 1000;
+        DateTime adjustedStart;
+        if (isWakeStart) {
+          adjustedStart = DateTime.fromMillisecondsSinceEpoch(
+            _wakeMagicEpochSeconds * 1000,
+            isUtc: true,
           );
-          adjustedStart = minScheduleTime;
+        } else {
+          final DateTime startUtc = DateTime(
+            start.year,
+            start.month,
+            start.day,
+            start.hour,
+            start.minute,
+          ).toUtc();
+
+          adjustedStart = startUtc;
+
+          final DateTime minScheduleTime =
+              DateTime.now().toUtc().add(const Duration(seconds: 5));
+          if (adjustedStart.isBefore(minScheduleTime)) {
+            debugPrint(
+              'Adjusting start time from ${startUtc.toIso8601String()} to ensure at least 5 seconds lead time',
+            );
+            adjustedStart = minScheduleTime;
+          }
         }
 
         final int startEpoch = adjustedStart.millisecondsSinceEpoch ~/ 1000;
         final int repeatPeriod = repeatSeconds;
-        const int repeatCount = 0xFFFFFFFF;
 
         final data = ByteData(20);
         data.setUint64(0, startEpoch, Endian.little);
@@ -831,13 +805,20 @@ class _CurrentTimePageState extends State<CurrentTimePage> {
 
         await scheduleChar.write(data.buffer.asUint8List(), withoutResponse: false);
         if (mounted) {
-          final localStart = DateTime.fromMillisecondsSinceEpoch(startEpoch * 1000).toLocal();
-          final time = TimeOfDay.fromDateTime(localStart).format(context);
-          final date = MaterialLocalizations.of(context).formatFullDate(localStart);
+          final String scheduleStartLabel;
+          if (isWakeStart) {
+            scheduleStartLabel = 'Start on Wake';
+          } else {
+            final localStart =
+                DateTime.fromMillisecondsSinceEpoch(startEpoch * 1000).toLocal();
+            final time = TimeOfDay.fromDateTime(localStart).format(context);
+            final date = MaterialLocalizations.of(context).formatFullDate(localStart);
+            scheduleStartLabel = '$date at $time';
+          }
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
                 content: Text(
-                    'Schedule set for $date at $time every $periodLabel, $amountMl ml')),
+                    'Schedule set for $scheduleStartLabel every $periodLabel, $amountMl ml')),
           );
         }
       } else {
@@ -864,15 +845,51 @@ class _CurrentTimePageState extends State<CurrentTimePage> {
       ),
     );
     if (result != null && mounted) {
+      const int repeatCountForever = 0xFFFFFFFF;
       final DateTime start = result['start'] as DateTime;
-      final int repeat = result['repeatSeconds'] as int;
-      final int amount = result['amountMl'] as int;
+      final int repeat = result['initialRepeatSeconds'] as int;
+      final int repeatCount = result['initialRepeatCount'] as int;
+      final int amount = result['initialAmountMl'] as int;
       final String label = _formatPeriod(repeat);
-      await _setSchedule(start, repeat, amount, label);
+      await _setSchedule(start, repeat, repeatCount, amount, label);
+
+      final int secondaryRepeat = result['secondaryRepeatSeconds'] as int;
+      final int secondaryRepeatCount = result['secondaryRepeatCount'] as int;
+      final int secondaryAmount = result['secondaryAmountMl'] as int;
+      if (secondaryRepeat > 0 && secondaryAmount > 0) {
+        if (repeatCount == repeatCountForever) {
+          if (mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                content: Text(
+                    'Secondary spray ignored because the initial repeat count is set to Forever.'),
+              ),
+            );
+          }
+          return;
+        }
+
+        final bool isWakeStart =
+            start.millisecondsSinceEpoch == _wakeMagicEpochSeconds * 1000;
+        final DateTime secondaryStart = isWakeStart
+            ? start
+            : start.add(Duration(seconds: repeat * repeatCount));
+        final String secondaryLabel = _formatPeriod(secondaryRepeat);
+        await _setSchedule(
+          secondaryStart,
+          secondaryRepeat,
+          secondaryRepeatCount,
+          secondaryAmount,
+          secondaryLabel,
+        );
+      }
     }
   }
 
   String _formatPeriod(int seconds) {
+    if (seconds == 0) {
+      return 'never';
+    }
     if (seconds >= 3600) {
       final hours = seconds ~/ 3600;
       return hours == 1 ? '1 hour' : '$hours hours';
@@ -934,7 +951,38 @@ class _CurrentTimePageState extends State<CurrentTimePage> {
                           color: Colors.white.withOpacity(0.8),
                           borderRadius: BorderRadius.circular(12),
                         ),
-                        child: _buildCalibrationSection(),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            const Text(
+                              'Calibration Data',
+                              style: TextStyle(
+                                  fontSize: 18, fontWeight: FontWeight.bold),
+                            ),
+                            const SizedBox(height: 8),
+                            Text(
+                              _calibrations.isEmpty
+                                  ? 'No calibration data yet.'
+                                  : '${_calibrations.length} calibration slots configured.',
+                            ),
+                            if (_calibrationError != null)
+                              Padding(
+                                padding: const EdgeInsets.only(top: 8),
+                                child: Text(
+                                  _calibrationError!,
+                                  style: const TextStyle(color: Colors.red),
+                                ),
+                              ),
+                            const SizedBox(height: 12),
+                            Align(
+                              alignment: Alignment.centerRight,
+                              child: TextButton(
+                                onPressed: _openCalibrationPage,
+                                child: const Text('View Calibration Details'),
+                              ),
+                            ),
+                          ],
+                        ),
                       ),
                       const SizedBox(height: 16),
                       Row(

--- a/lib/spray_schedule_page.dart
+++ b/lib/spray_schedule_page.dart
@@ -12,11 +12,49 @@ class SpraySchedulePage extends StatefulWidget {
 }
 
 class _SpraySchedulePageState extends State<SpraySchedulePage> {
+  static const int _wakeMagicEpochSeconds = 1;
+  static final DateTime _wakeMagicDateTime =
+      DateTime.fromMillisecondsSinceEpoch(
+    _wakeMagicEpochSeconds * 1000,
+    isUtc: true,
+  );
+
   late TimeOfDay _startTime;
   late DateTime _startDate;
-  int _repeatSeconds = 60;
+  bool _startOnWake = false;
+  int _initialRepeatSeconds = 60;
+  int _secondaryRepeatSeconds = 0;
+  int _initialRepeatCount = _repeatCountForever;
+  int _secondaryRepeatCount = _repeatCountForever;
   late List<int> _amountOptions;
-  int? _amountMl;
+  int _initialAmountMl = 0;
+  int _secondaryAmountMl = 0;
+
+  static const int _repeatCountForever = 0xFFFFFFFF;
+  static const List<int> _repeatCountOptions = [
+    1,
+    2,
+    3,
+    4,
+    5,
+    10,
+    20,
+    _repeatCountForever,
+  ];
+
+  static const List<_PeriodOption> _periodOptions = [
+    _PeriodOption(seconds: 0, label: 'Never'),
+    _PeriodOption(seconds: 30, label: '30 sec'),
+    _PeriodOption(seconds: 60, label: '1 min'),
+    _PeriodOption(seconds: 300, label: '5 min'),
+    _PeriodOption(seconds: 900, label: '15 min'),
+    _PeriodOption(seconds: 1800, label: '30 min'),
+    _PeriodOption(seconds: 3600, label: '1 hour'),
+    _PeriodOption(seconds: 7200, label: '2 hours'),
+    _PeriodOption(seconds: 21600, label: '6 hours'),
+    _PeriodOption(seconds: 43200, label: '12 hours'),
+    _PeriodOption(seconds: 86400, label: '24 hours'),
+  ];
 
   @override
   void initState() {
@@ -25,7 +63,7 @@ class _SpraySchedulePageState extends State<SpraySchedulePage> {
     _startTime = TimeOfDay.fromDateTime(_startDate);
     _amountOptions = widget.allowedAmounts.toSet().toList()..sort();
     if (_amountOptions.isNotEmpty) {
-      _amountMl = _amountOptions.first;
+      _initialAmountMl = _amountOptions.first;
     }
   }
 
@@ -57,21 +95,182 @@ class _SpraySchedulePageState extends State<SpraySchedulePage> {
   }
 
   void _save() {
-    if (_amountMl == null) {
+    if (_initialAmountMl == 0 || _initialRepeatSeconds == 0) {
       return;
     }
-    final startDateTime = DateTime(
-      _startDate.year,
-      _startDate.month,
-      _startDate.day,
-      _startTime.hour,
-      _startTime.minute,
-    );
+    final startDateTime = _startOnWake
+        ? _wakeMagicDateTime
+        : DateTime(
+            _startDate.year,
+            _startDate.month,
+            _startDate.day,
+            _startTime.hour,
+            _startTime.minute,
+          );
     Navigator.of(context).pop({
       'start': startDateTime,
-      'repeatSeconds': _repeatSeconds,
-      'amountMl': _amountMl!,
+      'initialRepeatSeconds': _initialRepeatSeconds,
+      'initialRepeatCount': _initialRepeatCount,
+      'initialAmountMl': _initialAmountMl,
+      'secondaryRepeatSeconds': _secondaryRepeatSeconds,
+      'secondaryRepeatCount': _secondaryRepeatCount,
+      'secondaryAmountMl': _secondaryAmountMl,
     });
+  }
+
+  Widget _buildStartModeButton({
+    required String label,
+    required bool isSelected,
+    required VoidCallback onPressed,
+  }) {
+    return Expanded(
+      child: GestureDetector(
+        onTap: onPressed,
+        child: Container(
+          padding: const EdgeInsets.all(2),
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(12),
+            gradient: isSelected
+                ? const LinearGradient(
+                    colors: [Color(0xFFFF9800), Color(0xFFFFB300)],
+                  )
+                : null,
+            border: isSelected
+                ? null
+                : Border.all(
+                    color: Colors.black.withOpacity(0.2),
+                  ),
+          ),
+          child: Container(
+            padding: const EdgeInsets.symmetric(vertical: 12),
+            decoration: BoxDecoration(
+              color: Colors.white.withOpacity(0.9),
+              borderRadius: BorderRadius.circular(10),
+            ),
+            child: Center(
+              child: Text(
+                label,
+                style: TextStyle(
+                  fontWeight: FontWeight.w600,
+                  color: isSelected ? Colors.deepOrange : Colors.black87,
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildScheduleSection({
+    required String title,
+    required int repeatSeconds,
+    required ValueChanged<int> onRepeatSecondsChanged,
+    required int amountMl,
+    required ValueChanged<int> onAmountChanged,
+    required int repeatCount,
+    required ValueChanged<int> onRepeatCountChanged,
+  }) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      margin: const EdgeInsets.only(top: 8),
+      decoration: BoxDecoration(
+        color: Colors.white.withOpacity(0.85),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: const TextStyle(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              const Text('Spray Period:'),
+              const SizedBox(width: 16),
+              DropdownButton<int>(
+                value: repeatSeconds,
+                onChanged: (value) {
+                  if (value != null) {
+                    onRepeatSecondsChanged(value);
+                  }
+                },
+                items: _periodOptions
+                    .map(
+                      (option) => DropdownMenuItem(
+                        value: option.seconds,
+                        child: Text(option.label),
+                      ),
+                    )
+                    .toList(),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              const Text('Amount:'),
+              const SizedBox(width: 16),
+              Expanded(
+                child: DropdownButton<int>(
+                  isExpanded: true,
+                  value: amountMl,
+                  onChanged: _amountOptions.isEmpty
+                      ? null
+                      : (value) {
+                          if (value != null) {
+                            onAmountChanged(value);
+                          }
+                        },
+                  items: [
+                    const DropdownMenuItem(
+                      value: 0,
+                      child: Text('None'),
+                    ),
+                    ..._amountOptions.map(
+                      (amount) => DropdownMenuItem(
+                        value: amount,
+                        child: Text('$amount ml'),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              const Text('Repeat Count:'),
+              const SizedBox(width: 16),
+              DropdownButton<int>(
+                value: repeatCount,
+                onChanged: (value) {
+                  if (value != null) {
+                    onRepeatCountChanged(value);
+                  }
+                },
+                items: _repeatCountOptions
+                    .map(
+                      (count) => DropdownMenuItem(
+                        value: count,
+                        child: Text(
+                          count == _repeatCountForever
+                              ? 'Forever'
+                              : '$count times',
+                        ),
+                      ),
+                    )
+                    .toList(),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
   }
 
   @override
@@ -93,84 +292,93 @@ class _SpraySchedulePageState extends State<SpraySchedulePage> {
           padding: const EdgeInsets.all(16),
           child: Column(
             children: [
-              ListTile(
-                title: const Text('Start Date'),
-                subtitle: Text(
-                  MaterialLocalizations.of(context).formatFullDate(_startDate),
-                ),
-                trailing: IconButton(
-                  icon: const Icon(Icons.calendar_today),
-                  onPressed: _pickStartDate,
-                ),
-              ),
-              const SizedBox(height: 8),
-              ListTile(
-                title: const Text('Start Time'),
-                subtitle: Text(_startTime.format(context)),
-                trailing: IconButton(
-                  icon: const Icon(Icons.access_time),
-                  onPressed: _pickStartTime,
-                ),
-              ),
-              const SizedBox(height: 16),
               Row(
                 children: [
-                  const Text('Repeat Every:'),
-                  const SizedBox(width: 16),
-                  DropdownButton<int>(
-                    value: _repeatSeconds,
-                    onChanged: (value) {
-                      if (value != null) {
-                        setState(() {
-                          _repeatSeconds = value;
-                        });
-                      }
+                  _buildStartModeButton(
+                    label: 'Start Date/Time',
+                    isSelected: !_startOnWake,
+                    onPressed: () {
+                      setState(() {
+                        _startOnWake = false;
+                      });
                     },
-                    items: const [
-                      DropdownMenuItem(value: 30, child: Text('30 sec')),
-                      DropdownMenuItem(value: 60, child: Text('1 min')),
-                      DropdownMenuItem(value: 300, child: Text('5 min')),
-                      DropdownMenuItem(value: 900, child: Text('15 min')),
-                      DropdownMenuItem(value: 1800, child: Text('30 min')),
-                      DropdownMenuItem(value: 3600, child: Text('1 hour')),
-                      DropdownMenuItem(value: 7200, child: Text('2 hours')),
-                      DropdownMenuItem(value: 21600, child: Text('6 hours')),
-                      DropdownMenuItem(value: 43200, child: Text('12 hours')),
-                      DropdownMenuItem(value: 86400, child: Text('24 hours')),
-                    ],
+                  ),
+                  const SizedBox(width: 12),
+                  _buildStartModeButton(
+                    label: 'Start on Wake',
+                    isSelected: _startOnWake,
+                    onPressed: () {
+                      setState(() {
+                        _startOnWake = true;
+                      });
+                    },
                   ),
                 ],
               ),
-              const SizedBox(height: 16),
-              Row(
-                children: [
-                  const Text('Amount:'),
-                  const SizedBox(width: 16),
-                  Expanded(
-                    child: DropdownButton<int>(
-                      isExpanded: true,
-                      value: _amountMl,
-                      hint: const Text('Select amount'),
-                      onChanged: _amountOptions.isEmpty
-                          ? null
-                          : (value) {
-                              if (value != null) {
-                                setState(() {
-                                  _amountMl = value;
-                                });
-                              }
-                            },
-                      items: _amountOptions
-                          .map(
-                            (amount) => DropdownMenuItem(
-                              value: amount,
-                              child: Text('$amount ml'),
-                            ),
-                          )
-                          .toList(),
-                    ),
+              if (!_startOnWake) ...[
+                const SizedBox(height: 12),
+                ListTile(
+                  title: const Text('Start Date'),
+                  subtitle: Text(
+                    MaterialLocalizations.of(context).formatFullDate(_startDate),
                   ),
-                ],
+                  trailing: IconButton(
+                    icon: const Icon(Icons.calendar_today),
+                    onPressed: _pickStartDate,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                ListTile(
+                  title: const Text('Start Time'),
+                  subtitle: Text(_startTime.format(context)),
+                  trailing: IconButton(
+                    icon: const Icon(Icons.access_time),
+                    onPressed: _pickStartTime,
+                  ),
+                ),
+              ],
+              const SizedBox(height: 16),
+              _buildScheduleSection(
+                title: 'Initial Spray',
+                repeatSeconds: _initialRepeatSeconds,
+                onRepeatSecondsChanged: (value) {
+                  setState(() {
+                    _initialRepeatSeconds = value;
+                  });
+                },
+                amountMl: _initialAmountMl,
+                onAmountChanged: (value) {
+                  setState(() {
+                    _initialAmountMl = value;
+                  });
+                },
+                repeatCount: _initialRepeatCount,
+                onRepeatCountChanged: (value) {
+                  setState(() {
+                    _initialRepeatCount = value;
+                  });
+                },
+              ),
+              _buildScheduleSection(
+                title: 'Secondary Spray',
+                repeatSeconds: _secondaryRepeatSeconds,
+                onRepeatSecondsChanged: (value) {
+                  setState(() {
+                    _secondaryRepeatSeconds = value;
+                  });
+                },
+                amountMl: _secondaryAmountMl,
+                onAmountChanged: (value) {
+                  setState(() {
+                    _secondaryAmountMl = value;
+                  });
+                },
+                repeatCount: _secondaryRepeatCount,
+                onRepeatCountChanged: (value) {
+                  setState(() {
+                    _secondaryRepeatCount = value;
+                  });
+                },
               ),
               if (_amountOptions.isEmpty)
                 const Padding(
@@ -182,7 +390,10 @@ class _SpraySchedulePageState extends State<SpraySchedulePage> {
                 ),
               const Spacer(),
               ElevatedButton(
-                onPressed: _amountMl == null ? null : _save,
+                onPressed:
+                    _initialAmountMl == 0 || _initialRepeatSeconds == 0
+                        ? null
+                        : _save,
                 style: ElevatedButton.styleFrom(
                   backgroundColor: Colors.amber.shade700,
                   foregroundColor: Colors.black,
@@ -195,4 +406,11 @@ class _SpraySchedulePageState extends State<SpraySchedulePage> {
       ),
     );
   }
+}
+
+class _PeriodOption {
+  final int seconds;
+  final String label;
+
+  const _PeriodOption({required this.seconds, required this.label});
 }

--- a/lib/spray_schedule_page.dart
+++ b/lib/spray_schedule_page.dart
@@ -7,8 +7,13 @@ import 'package:path_provider/path_provider.dart';
 
 class SpraySchedulePage extends StatefulWidget {
   final List<int> allowedAmounts;
+  final SprayScheduleInitialData? initialData;
 
-  const SpraySchedulePage({super.key, required this.allowedAmounts});
+  const SpraySchedulePage({
+    super.key,
+    required this.allowedAmounts,
+    this.initialData,
+  });
 
   @override
   State<SpraySchedulePage> createState() => _SpraySchedulePageState();
@@ -49,6 +54,7 @@ class _SpraySchedulePageState extends State<SpraySchedulePage> {
     _PeriodOption(seconds: 3600, label: '1 hour'),
     _PeriodOption(seconds: 7200, label: '2 hours'),
     _PeriodOption(seconds: 21600, label: '6 hours'),
+    _PeriodOption(seconds: 28800, label: '8 hours'),
     _PeriodOption(seconds: 43200, label: '12 hours'),
     _PeriodOption(seconds: 86400, label: '24 hours'),
   ];
@@ -59,9 +65,36 @@ class _SpraySchedulePageState extends State<SpraySchedulePage> {
     super.initState();
     _startDate = DateTime.now();
     _startTime = TimeOfDay.fromDateTime(_startDate);
-    _amountOptions = widget.allowedAmounts.toSet().toList()..sort();
+    final Set<int> amountSet = widget.allowedAmounts.toSet();
+    final SprayScheduleInitialData? initial = widget.initialData;
+    if (initial != null) {
+      if (initial.initialAmountMl > 0) {
+        amountSet.add(initial.initialAmountMl);
+      }
+      if (initial.secondaryAmountMl > 0) {
+        amountSet.add(initial.secondaryAmountMl);
+      }
+    }
+    _amountOptions = amountSet.toList()..sort();
     if (_amountOptions.isNotEmpty) {
       _initialAmountMl = _amountOptions.first;
+    }
+    if (initial != null) {
+      final DateTime localStart = initial.start.toLocal();
+      _startOnWake = initial.startOnWake;
+      _startDate = DateTime(localStart.year, localStart.month, localStart.day);
+      _startTime = TimeOfDay.fromDateTime(localStart);
+      _initialRepeatSeconds =
+          _coerceRepeat(initial.initialRepeatSeconds, _initialRepeatSeconds);
+      _secondaryRepeatSeconds =
+          _coerceRepeat(initial.secondaryRepeatSeconds, _secondaryRepeatSeconds);
+      _initialRepeatCount =
+          _coerceRepeatCount(initial.initialRepeatCount, _initialRepeatCount);
+      _secondaryRepeatCount =
+          _coerceRepeatCount(initial.secondaryRepeatCount, _secondaryRepeatCount);
+      _initialAmountMl = _coerceAmount(initial.initialAmountMl, _initialAmountMl);
+      _secondaryAmountMl =
+          _coerceAmount(initial.secondaryAmountMl, _secondaryAmountMl);
     }
   }
 
@@ -590,4 +623,26 @@ class _PeriodOption {
   final String label;
 
   const _PeriodOption({required this.seconds, required this.label});
+}
+
+class SprayScheduleInitialData {
+  final DateTime start;
+  final bool startOnWake;
+  final int initialRepeatSeconds;
+  final int initialRepeatCount;
+  final int initialAmountMl;
+  final int secondaryRepeatSeconds;
+  final int secondaryRepeatCount;
+  final int secondaryAmountMl;
+
+  const SprayScheduleInitialData({
+    required this.start,
+    required this.startOnWake,
+    required this.initialRepeatSeconds,
+    required this.initialRepeatCount,
+    required this.initialAmountMl,
+    required this.secondaryRepeatSeconds,
+    required this.secondaryRepeatCount,
+    required this.secondaryAmountMl,
+  });
 }

--- a/lib/spray_schedule_page.dart
+++ b/lib/spray_schedule_page.dart
@@ -99,11 +99,14 @@ class _SpraySchedulePageState extends State<SpraySchedulePage> {
   }
 
   Future<void> _pickStartDate() async {
+    final DateTime now = DateTime.now();
+    final DateTime today = DateTime(now.year, now.month, now.day);
+    final DateTime initialDate = _startDate.isBefore(today) ? today : _startDate;
     final DateTime? picked = await showDatePicker(
       context: context,
-      initialDate: _startDate,
-      firstDate: DateTime.now(),
-      lastDate: DateTime.now().add(const Duration(days: 365 * 5)),
+      initialDate: initialDate,
+      firstDate: today,
+      lastDate: today.add(const Duration(days: 365 * 5)),
     );
 
     if (picked != null) {

--- a/lib/spray_schedule_page.dart
+++ b/lib/spray_schedule_page.dart
@@ -32,6 +32,7 @@ class _SpraySchedulePageState extends State<SpraySchedulePage> {
 
   static const int _repeatCountForever = 0xFFFFFFFF;
   static const List<int> _repeatCountOptions = [
+    0,
     1,
     2,
     3,

--- a/lib/spray_schedule_page.dart
+++ b/lib/spray_schedule_page.dart
@@ -31,15 +31,8 @@ class _SpraySchedulePageState extends State<SpraySchedulePage> {
   int _secondaryAmountMl = 0;
 
   static const int _repeatCountForever = 0xFFFFFFFF;
-  static const List<int> _repeatCountOptions = [
-    0,
-    1,
-    2,
-    3,
-    4,
-    5,
-    10,
-    20,
+  static final List<int> _repeatCountOptions = [
+    ...List<int>.generate(21, (index) => index),
     _repeatCountForever,
   ];
 
@@ -96,9 +89,6 @@ class _SpraySchedulePageState extends State<SpraySchedulePage> {
   }
 
   void _save() {
-    if (_initialAmountMl == 0 || _initialRepeatSeconds == 0) {
-      return;
-    }
     final startDateTime = _startOnWake
         ? _wakeMagicDateTime
         : DateTime(
@@ -391,10 +381,7 @@ class _SpraySchedulePageState extends State<SpraySchedulePage> {
                 ),
               const Spacer(),
               ElevatedButton(
-                onPressed:
-                    _initialAmountMl == 0 || _initialRepeatSeconds == 0
-                        ? null
-                        : _save,
+                onPressed: _save,
                 style: ElevatedButton.styleFrom(
                   backgroundColor: Colors.amber.shade700,
                   foregroundColor: Colors.black,

--- a/lib/spray_schedule_page.dart
+++ b/lib/spray_schedule_page.dart
@@ -1,6 +1,9 @@
+import 'dart:convert';
+import 'dart:io';
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
+import 'package:path_provider/path_provider.dart';
 
 class SpraySchedulePage extends StatefulWidget {
   final List<int> allowedAmounts;
@@ -49,6 +52,7 @@ class _SpraySchedulePageState extends State<SpraySchedulePage> {
     _PeriodOption(seconds: 43200, label: '12 hours'),
     _PeriodOption(seconds: 86400, label: '24 hours'),
   ];
+  static const String _savedConfigFileName = 'spray_schedule_saved_config.json';
 
   @override
   void initState() {
@@ -88,7 +92,154 @@ class _SpraySchedulePageState extends State<SpraySchedulePage> {
     }
   }
 
-  void _save() {
+  int _coerceAmount(dynamic value, int fallback) {
+    final int? candidate = switch (value) {
+      int v => v,
+      String v => int.tryParse(v),
+      _ => null,
+    };
+    if (candidate == null) {
+      return fallback;
+    }
+    if (candidate == 0 || _amountOptions.contains(candidate)) {
+      return candidate;
+    }
+    return fallback;
+  }
+
+  int _coerceRepeat(dynamic value, int fallback) {
+    final int? candidate = switch (value) {
+      int v => v,
+      String v => int.tryParse(v),
+      _ => null,
+    };
+    if (candidate == null) {
+      return fallback;
+    }
+    return _periodOptions.any((option) => option.seconds == candidate)
+        ? candidate
+        : fallback;
+  }
+
+  int _coerceRepeatCount(dynamic value, int fallback) {
+    final int? candidate = switch (value) {
+      int v => v,
+      String v => int.tryParse(v),
+      _ => null,
+    };
+    if (candidate == null) {
+      return fallback;
+    }
+    return _repeatCountOptions.contains(candidate) ? candidate : fallback;
+  }
+
+  Future<File> _savedConfigFile() async {
+    final Directory directory = await getApplicationDocumentsDirectory();
+    return File('${directory.path}/$_savedConfigFileName');
+  }
+
+  Map<String, dynamic> _currentStateAsJson() {
+    return {
+      'startOnWake': _startOnWake,
+      'startDateYear': _startDate.year,
+      'startDateMonth': _startDate.month,
+      'startDateDay': _startDate.day,
+      'startTimeHour': _startTime.hour,
+      'startTimeMinute': _startTime.minute,
+      'initialRepeatSeconds': _initialRepeatSeconds,
+      'secondaryRepeatSeconds': _secondaryRepeatSeconds,
+      'initialRepeatCount': _initialRepeatCount,
+      'secondaryRepeatCount': _secondaryRepeatCount,
+      'initialAmountMl': _initialAmountMl,
+      'secondaryAmountMl': _secondaryAmountMl,
+    };
+  }
+
+  Future<void> _saveConfigSnapshot() async {
+    final File file = await _savedConfigFile();
+    await file.writeAsString(jsonEncode(_currentStateAsJson()), flush: true);
+  }
+
+  Future<void> _restoreConfigSnapshot() async {
+    try {
+      final File file = await _savedConfigFile();
+      if (!await file.exists()) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('No saved schedule configuration found.')),
+          );
+        }
+        return;
+      }
+
+      final String content = await file.readAsString();
+      final dynamic parsed = jsonDecode(content);
+      if (parsed is! Map<String, dynamic>) {
+        throw const FormatException('Invalid saved schedule configuration format');
+      }
+
+      setState(() {
+        final bool restoredStartOnWake = parsed['startOnWake'] == true;
+        final int year = (parsed['startDateYear'] as num?)?.toInt() ?? _startDate.year;
+        final int month = (parsed['startDateMonth'] as num?)?.toInt() ?? _startDate.month;
+        final int day = (parsed['startDateDay'] as num?)?.toInt() ?? _startDate.day;
+        _startDate = DateTime(year, month, day);
+
+        final int hour = (parsed['startTimeHour'] as num?)?.toInt() ?? _startTime.hour;
+        final int minute =
+            (parsed['startTimeMinute'] as num?)?.toInt() ?? _startTime.minute;
+        _startTime = TimeOfDay(
+          hour: hour.clamp(0, 23).toInt(),
+          minute: minute.clamp(0, 59).toInt(),
+        );
+
+        _startOnWake = restoredStartOnWake;
+        _initialRepeatSeconds =
+            _coerceRepeat(parsed['initialRepeatSeconds'], _initialRepeatSeconds);
+        _secondaryRepeatSeconds =
+            _coerceRepeat(parsed['secondaryRepeatSeconds'], _secondaryRepeatSeconds);
+        _initialRepeatCount =
+            _coerceRepeatCount(parsed['initialRepeatCount'], _initialRepeatCount);
+        _secondaryRepeatCount =
+            _coerceRepeatCount(parsed['secondaryRepeatCount'], _secondaryRepeatCount);
+        _initialAmountMl = _coerceAmount(parsed['initialAmountMl'], _initialAmountMl);
+        _secondaryAmountMl = _coerceAmount(parsed['secondaryAmountMl'], _secondaryAmountMl);
+      });
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Schedule configuration restored.')),
+        );
+      }
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Unable to restore saved configuration.')),
+        );
+      }
+    }
+  }
+
+  Future<void> _saveConfigOnly() async {
+    try {
+      await _saveConfigSnapshot();
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Unable to save schedule configuration.')),
+        );
+      }
+      return;
+    }
+
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Schedule configuration saved.')),
+      );
+    }
+  }
+
+  void _writeToVcd() {
     final startDateTime = _startOnWake
         ? _wakeMagicDateTime
         : DateTime(
@@ -266,6 +417,7 @@ class _SpraySchedulePageState extends State<SpraySchedulePage> {
 
   @override
   Widget build(BuildContext context) {
+    final double bottomActionInset = MediaQuery.of(context).size.height * 0.05;
     return Scaffold(
       appBar: AppBar(
         title: const Text('Spray Schedule'),
@@ -380,13 +532,50 @@ class _SpraySchedulePageState extends State<SpraySchedulePage> {
                   ),
                 ),
               const Spacer(),
-              ElevatedButton(
-                onPressed: _save,
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.amber.shade700,
-                  foregroundColor: Colors.black,
+              SafeArea(
+                top: false,
+                minimum: EdgeInsets.only(bottom: bottomActionInset),
+                child: Column(
+                  children: [
+                    SizedBox(
+                      width: double.infinity,
+                      child: ElevatedButton(
+                        onPressed: _writeToVcd,
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: Colors.amber.shade700,
+                          foregroundColor: Colors.black,
+                        ),
+                        child: const Text('Write to VCD'),
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    Row(
+                      children: <Widget>[
+                        Expanded(
+                          child: ElevatedButton(
+                            onPressed: _restoreConfigSnapshot,
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: Colors.amber.shade300,
+                              foregroundColor: Colors.black,
+                            ),
+                            child: const Text('Restore From File'),
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: ElevatedButton(
+                            onPressed: _saveConfigOnly,
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: Colors.amber.shade700,
+                              foregroundColor: Colors.black,
+                            ),
+                            child: const Text('Save To File'),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
                 ),
-                child: const Text('Save'),
               ),
             ],
           ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -224,6 +224,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_provider:
+    dependency: "direct main"
+    description:
+      name: path_provider
+      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.5"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: "3b4c1fc3aa55ddc9cd4aa6759984330d5c8e66aa7702a6223c61540dc6380c37"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.19"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "16eef174aacb07e09c351502740fa6254c165757638eba1e9116b0a781201bbd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
   permission_handler:
     dependency: "direct main"
     description:
@@ -280,6 +328,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.1.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -373,6 +429,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      sha256: "7a3f37b05d989967cdddcbb571f1ea834867ae2faa29725fd085180e0883aa15"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   xml:
     dependency: transitive
     description:
@@ -383,4 +447,4 @@ packages:
     version: "6.5.0"
 sdks:
   dart: ">=3.8.1 <4.0.0"
-  flutter: ">=3.24.0"
+  flutter: ">=3.29.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+1
+version: 2.0.0+1
 
 environment:
   sdk: ^3.8.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   # application may not be able to scan or connect to BLE devices on
   # Android.
   permission_handler: ^12.0.1
+  path_provider: ^2.1.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### Motivation
- Move the device calibration listing out of the main device screen into a dedicated sub-page to declutter the main UI and provide refresh/edit flows.
- Allow configuring two sequential spray patterns (initial + secondary) including explicit `repeatCount` so an initial pattern can run N times then switch to a secondary pattern.
- Ensure the schedule payload sent to the device over BLE contains the new `repeatCount` field and that `Start on Wake` is supported via a wake-magic timestamp.

### Description
- Added `lib/calibration_entry.dart` model and a new `CalibrationPage` in `lib/calibration_page.dart` with refresh and per-slot edit actions, and wired navigation from the main device page via `_openCalibrationPage` and `_refreshCalibrationData` in `lib/main.dart`.
- Reworked the main device screen to show a compact calibration summary and a `View Calibration Details` link that opens the new calibration sub-page instead of listing full entries inline.
- Extended schedule handling: updated `_setSchedule` in `lib/main.dart` to accept `repeatCount` and write it into the BLE schedule payload (`ByteData` at offset 12), added wake-start detection to skip min-lead-time adjustment when `Start on Wake` is chosen, and updated schedule confirmation labels accordingly.
- Implemented secondary schedule support: `SpraySchedulePage` now returns `initial*` and `secondary*` fields, and `lib/main.dart` sends the primary schedule then optionally computes and sends a secondary schedule start (skipping if initial `repeatCount` is `0xFFFFFFFF` meaning Forever) so the device receives both schedules over BLE.
- Reworked `lib/spray_schedule_page.dart` UI to add a `Start Date/Time` vs `Start on Wake` toggle, separate `Initial Spray` and `Secondary Spray` sections with `Spray Period` (including `Never`), `Amount` (including `None`), and `Repeat Count` (numeric options plus `Forever` as `0xFFFFFFFF`).

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_697ab530a0a08323ac9937995d8dc2c4)